### PR TITLE
runTest.py: `make test` now correctly implements attestation tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -191,5 +191,6 @@ operations_minimal_tests:=$(wildcard tests/eth2.0-spec-tests/tests/minimal/phase
 
 test-operations-minimal: $(operations_minimal_tests:=.test-parse)
 
+# Add argument --debug to python3 command, to keep temporary json file.
 %.yaml.test-parse: %.yaml $(llvm_kompiled)
-	python3 runTest.py parse --input $*.yaml
+	python3 runTest.py parse --pre $*.yaml --type attestation

--- a/beacon-chain.k
+++ b/beacon-chain.k
@@ -2419,7 +2419,7 @@ def process_attestation(state: BeaconState, attestation: Attestation) -> None:
     # Check signature
     assert is_valid_indexed_attestation(state, get_indexed_attestation(state, attestation))
 */
-  syntax KItem ::= "process_attestation" "(" Attestation ")"
+  syntax KItem ::= "process_attestation" "(" Attestation ")" [klabel(process_attestation), symbol]
   rule <k> process_attestation( ATT )
            => process_attestation_if(ATT, #PendingAttestation(ATT.aggregation_bits,
                                                               ATT._data,

--- a/types.k
+++ b/types.k
@@ -432,7 +432,7 @@ class Attestation(Container):
     custody_bits: Bitlist[MAX_VALIDATORS_PER_COMMITTEE]
     signature: BLSSignature
   */
-  syntax Attestation ::= #Attestation( BitList, AttestationData, BitList, BLSSignature )
+  syntax Attestation ::= #Attestation( BitList, AttestationData, BitList, BLSSignature ) [klabel(#Attestation), symbol]
 
   syntax BitList ::= Attestation "." "aggregation_bits"               [function]
   rule #Attestation(AggrBITS, _,_,_).aggregation_bits => AggrBITS


### PR DESCRIPTION
Invokes `process_attestation` with correct argument.

The test format has changed in BC v0.8.2. Now there's 1 dir for each test, with 1+ files inside. For now only tests for `process_attestation` were ported. They use 2 files: `pre.xaml` for state, and `attestation.xaml` for the attestation. These tests should invoke `process_attestation(attestation)`.

I also added option `--debug` to runTest.py, to keep the temp files.


