### PR TITLE
0.10bounds

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,10 +2,6 @@
 	path = deps/k
 	url = https://github.com/kframework/k
 	ignore = untracked
-[submodule "deps/pandoc-tangle"]
-	path = deps/pandoc-tangle
-	url = https://github.com/ehildenb/pandoc-tangle
-	ignore = untracked
 [submodule "tests/eth2.0-spec-tests"]
 	path = tests/eth2.0-spec-tests
 	url = https://github.com/ethereum/eth2.0-spec-tests

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,8 +37,8 @@ pipeline {
     stage('Publish to Jenkins') {
       steps {
         sh '''
-          deps/k/k-distribution/target/release/k/bin/kcovr .build/defn/llvm/beacon-chain-kompiled \
-            -- .build/defn/llvm/*.k      \
+          deps/k/k-distribution/target/release/k/bin/kcovr .build/defn/llvm-minimal/beacon-chain-kompiled \
+            -- .build/defn/llvm-minimal/*.k      \
             > coverage.xml
         '''
         cobertura coberturaReportFile: 'coverage.xml'

--- a/Makefile
+++ b/Makefile
@@ -150,6 +150,7 @@ KOMPILE_OPTS      ?=
 LLVM_KOMPILE_OPTS := $(KOMPILE_OPTS)
 
 llvm_kompiled    := $(llvm_dir_minimal)/$(MAIN_DEFN_FILE)-kompiled/interpreter
+llvm_kompiled_bounds    := $(llvm_dir_bounds)/$(MAIN_DEFN_FILE)-kompiled/interpreter
 haskell_kompiled := $(haskell_dir)/$(MAIN_DEFN_FILE)-kompiled/definition.kore
 
 build: build-llvm build-haskell
@@ -225,10 +226,10 @@ test-llvm: test-python-config-llvm test-all-llvm
 test-bounds: test-python-config-llvm-bounds test-epoch-processing-bounds
 
 test-python-config-llvm-bounds: $(llvm_kompiled_bounds)
-	python3 buildConfig.py -b llvm
+	python3 buildConfig.py -b llvm-bounds
 
 test-python-config-llvm: $(llvm_kompiled)
-	python3 buildConfig.py -b llvm
+	python3 buildConfig.py -b llvm-minimal
 
 test-processing: $(all_process_tests:=.test)
 
@@ -237,26 +238,26 @@ test-ssz: $(ssz_tests:=.test)
 test-all-llvm: $(all_tests:=.test)
 
 %.yaml.bounds-test: %.yaml $(llvm_kompiled_bounds)
-	python3 runTest.py parse -b llvm --test $*.yaml
+	python3 runTest.py parse -b llvm-bounds --test $*.yaml
 
 %.yaml.bounds-test-allow-diff: %.yaml $(llvm_kompiled_bounds)
-	python3 runTest.py parse -b llvm --test $*.yaml --allow-diff
+	python3 runTest.py parse -b llvm-bounds --test $*.yaml --allow-diff
 
 # Same as above, but invokes krun with --debug and does not halt when diff vs expected state is detected
 %.yaml.bounds-test-debug: %.yaml $(llvm_kompiled_bounds)
-	python3 runTest.py parse -b llvm --test $*.yaml --debug --allow-diff
+	python3 runTest.py parse -b llvm-bounds --test $*.yaml --debug --allow-diff
 
 test-epoch-processing-bounds: tests/eth2.0-spec-tests/tests/minimal/phase0/epoch_processing/rewards_and_penalties/pyspec_tests/attestations_some_slashed/pre.yaml.bounds-test
 
 %.yaml.test: %.yaml $(llvm_kompiled)
-	python3 runTest.py parse -b llvm --test $*.yaml
+	python3 runTest.py parse -b llvm-minimal --test $*.yaml
 
 %.yaml.test-allow-diff: %.yaml $(llvm_kompiled)
-	python3 runTest.py parse -b llvm --test $*.yaml --allow-diff
+	python3 runTest.py parse -b llvm-minimal --test $*.yaml --allow-diff
 
 # Same as above, but invokes krun with --debug and does not halt when diff vs expected state is detected
 %.yaml.test-debug: %.yaml $(llvm_kompiled)
-	python3 runTest.py parse -b llvm --test $*.yaml --debug --allow-diff
+	python3 runTest.py parse -b llvm-minimal --test $*.yaml --debug --allow-diff
 
 # Testing on Haskell Backend
 

--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,7 @@ MAIN_DEFN_FILE := beacon-chain
 
 # Generate definitions from source files
 
-k_files := $(MAIN_DEFN_FILE).k beacon-chain.k hash-tree.k types.k config.k constants-minimal.k
+k_files := $(MAIN_DEFN_FILE).k beacon-chain.k hash-tree.k types.k config.k constants-mainnet.k uint64.k
 
 llvm_dir   := $(DEFN_DIR)/llvm
 llvm_files := $(patsubst %,$(llvm_dir)/%,$(k_files))

--- a/Makefile
+++ b/Makefile
@@ -172,7 +172,7 @@ $(llvm_kompiled): $(llvm_files) $(libff_out)
 	                 -ccopt -lsecp256k1                                               \
 	                 $(LLVM_KOMPILE_OPTS)
 
-# LLVM Backend (configuration: minimal)
+# LLVM Backend (configuration: bounds-check)
 
 $(llvm_kompiled_bounds): $(llvm_bounds_files) $(libff_out)
 	$(K_BIN)/kompile --debug --main-module $(MAIN_MODULE) --backend llvm              \
@@ -222,7 +222,7 @@ test: test-llvm test-bounds
 
 test-llvm: test-python-config-llvm test-all-llvm
 
-test-bounds: test-python-config-llvm-bounds test-all-bounds
+test-bounds: test-python-config-llvm-bounds test-epoch-processing-bounds
 
 test-python-config-llvm-bounds: $(llvm_kompiled_bounds)
 	python3 buildConfig.py -b llvm
@@ -246,7 +246,7 @@ test-all-llvm: $(all_tests:=.test)
 %.yaml.bounds-test-debug: %.yaml $(llvm_kompiled_bounds)
 	python3 runTest.py parse -b llvm --test $*.yaml --debug --allow-diff
 
-test-all-bounds: $(all_tests:=.bounds-test)
+test-epoch-processing-bounds: tests/eth2.0-spec-tests/tests/minimal/phase0/epoch_processing/rewards_and_penalties/pyspec_tests/attestations_some_slashed/pre.yaml.bounds-test
 
 %.yaml.test: %.yaml $(llvm_kompiled)
 	python3 runTest.py parse -b llvm --test $*.yaml

--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,7 @@ MAIN_DEFN_FILE := beacon-chain
 
 k_files := $(MAIN_DEFN_FILE).k hash-tree.k types.k config.k constants-minimal.k uint64.k
 
-bounds_files := $(MAIN_DEFN_FILE).k hash-tree.k types.k config.k constants-bounds-check.k uint64.k
+bounds_files := $(MAIN_DEFN_FILE).k hash-tree.k types.k config.k uint64.k constants-minimal.k
 
 llvm_dir_minimal  := $(DEFN_DIR)/llvm-minimal
 llvm_dir_bounds   := $(DEFN_DIR)/llvm-bounds
@@ -136,8 +136,16 @@ defn: llvm-defn haskell-defn
 defn-llvm:    $(llvm_files)
 defn-haskell: $(haskell_files)
 
-$(llvm_dir_minimal)/%.k: %.k
+$(llvm_dir_minimal)/%.k: $(k_files)
 	@mkdir -p $(llvm_dir_minimal)
+	cp $< $@
+
+$(llvm_dir_bounds)/constants-minimal.k: constants-bounds-check.k
+	@mkdir -p $(llvm_dir_bounds)
+	cp $< $@
+
+$(llvm_dir_bounds)/%.k: %.k
+	@mkdir -p $(llvm_dir_bounds)
 	cp $< $@
 
 $(haskell_dir)/%.k: %.k

--- a/Makefile
+++ b/Makefile
@@ -177,7 +177,7 @@ $(llvm_kompiled): $(llvm_files) $(libff_out)
 $(llvm_kompiled_bounds): $(llvm_bounds_files) $(libff_out)
 	$(K_BIN)/kompile --debug --main-module $(MAIN_MODULE) --backend llvm              \
 	                 --syntax-module $(SYNTAX_MODULE) $(llvm_dir_bounds)/$(MAIN_DEFN_FILE).k \
-	                 --directory $(llvm_dir) -I $(llvm_dir_bounds)                           \
+	                 --directory $(llvm_dir_bounds) -I $(llvm_dir_bounds)                           \
 	                 --hook-namespaces KRYPTO                                         \
 	                 --emit-json                                                      \
 	                 -ccopt ${PLUGIN_SUBMODULE}/plugin-c/crypto.cpp                   \

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,6 @@ export PKG_CONFIG_PATH
 
 DEPS_DIR                := deps
 K_SUBMODULE             := $(abspath $(DEPS_DIR)/k)
-PANDOC_TANGLE_SUBMODULE := $(DEPS_DIR)/pandoc-tangle
 PLUGIN_SUBMODULE        := $(abspath $(DEPS_DIR)/plugin)
 
 K_RELEASE := $(K_SUBMODULE)/k-distribution/target/release/k
@@ -28,17 +27,12 @@ export PATH
 PYTHONPATH := $(K_LIB)
 export PYTHONPATH
 
-TANGLER  := $(PANDOC_TANGLE_SUBMODULE)/tangle.lua
-LUA_PATH := $(PANDOC_TANGLE_SUBMODULE)/?.lua;;
-export TANGLER
-export LUA_PATH
-
 TEST_DIR             := tests
 ETH2_TESTS_SUBMODULE := $(TEST_DIR)/eth2.0-spec-tests
 
 .PHONY: all clean                                      \
         libff libsecp256k1                             \
-        deps deps-k deps-tangle deps-plugin deps-tests \
+        deps deps-k deps-plugin deps-tests             \
         defn defn-llvm defn-haskell                    \
         build build-llvm build-haskell                 \
         test test-split test-python-config test-processing test-ssz
@@ -50,7 +44,7 @@ clean:
 	rm -rf $(BUILD_DIR)
 
 clean-submodules:
-	rm -rf $(DEPS_DIR)/k/submodule.timestamp $(DEPS_DIR)/k/mvn.timestamp $(DEPS_DIR)/pandoc-tangle/submodule.timestamp tests/eth2.0-specs/submodule.timestamp
+	rm -rf $(DEPS_DIR)/k/submodule.timestamp $(DEPS_DIR)/k/mvn.timestamp tests/eth2.0-specs/submodule.timestamp
 	cd $(DEPS_DIR)/k         && mvn clean --quiet
 	cd $(DEPS_DIR)/secp256k1 && make distclean || true
 
@@ -100,9 +94,8 @@ $(libff_out): $(DEPS_DIR)/libff/CMakeLists.txt
 # Dependencies
 # ------------
 
-deps: deps-k deps-tangle deps-tests deps-plugin
+deps: deps-k deps-tests deps-plugin
 deps-k:      $(K_SUBMODULE)/mvn.timestamp
-deps-tangle: $(PANDOC_TANGLE_SUBMODULE)/submodule.timestamp
 deps-tests:  $(ETH2_TESTS_SUBMODULE)/submodule.timestamp
 deps-plugin: $(PLUGIN_SUBMODULE)/make.timestamp
 

--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,7 @@ defn: llvm-defn haskell-defn
 defn-llvm:    $(llvm_files)
 defn-haskell: $(haskell_files)
 
-$(llvm_dir_minimal)/%.k: $(k_files)
+$(llvm_dir_minimal)/%.k: %.k
 	@mkdir -p $(llvm_dir_minimal)
 	cp $< $@
 

--- a/beacon-chain.k
+++ b/beacon-chain.k
@@ -1318,7 +1318,9 @@ def get_attestation_deltas(state: BeaconState) -> Tuple[Sequence[Gwei], Sequence
         attesting_balance = get_total_balance(state, unslashed_attesting_indices)
         for index in eligible_validator_indices:
             if index in unslashed_attesting_indices:
-                rewards[index] += get_base_reward(state, index) * attesting_balance // total_balance
+                increment = EFFECTIVE_BALANCE_INCREMENT  # Factored out from balance totals to avoid uint64 overflow
+                reward_numerator = get_base_reward(state, index) * (attesting_balance // increment)
+                rewards[index] = reward_numerator // (total_balance // increment)
             else:
                 penalties[index] += get_base_reward(state, index)
 
@@ -1403,8 +1405,11 @@ def get_attestation_deltas(state: BeaconState) -> Tuple[Sequence[Gwei], Sequence
                        AttestingBalance,
                        #mapMapPair(Rewards => #if contains(I, UnslashedIndices)
                                               #then Rewards[I <- ei(0, 2 ^Int 64 -Int 1, ci({Rewards[I]}:>Int) +UInt64 get_base_reward(I)
-                                                                  *UInt64 ui(MAX_EFFECTIVE_BALANCE, MAX_ATTESTING_BALANCE, AttestingBalance)
-                                                                  /UInt64 ui(MAX_EFFECTIVE_BALANCE, TOTAL_ETHER_SUPPLY, TotalBalance))]
+                                                                  *UInt64 ( ui(MAX_EFFECTIVE_BALANCE, MAX_ATTESTING_BALANCE, AttestingBalance)
+                                                                  /UInt64 ci(EFFECTIVE_BALANCE_INCREMENT))
+                                                                  /UInt64 ( ui(MAX_EFFECTIVE_BALANCE, TOTAL_ETHER_SUPPLY, TotalBalance)
+                                                                  /UInt64 ci(EFFECTIVE_BALANCE_INCREMENT)))
+                                                                  ]
                                               #else Rewards
                                               #fi,
                                   Penalties => #if notBool contains(I, UnslashedIndices)

--- a/beacon-chain.k
+++ b/beacon-chain.k
@@ -4,10 +4,12 @@
  */
 
 requires "hash-tree.k"
+requires "uint64.k"
 
 module BEACON-CHAIN
   imports DOMAINS
   imports HASH-TREE
+  imports UINT64
 
   // Hacks around pyk/json front-end limitations
   //====================================================
@@ -1290,10 +1292,13 @@ def get_base_reward(state: BeaconState, index: ValidatorIndex) -> Gwei:
 */
   syntax Int ::= "get_base_reward" "(" Int ")" [function]
   rule get_base_reward(INDEX)
-       => getValidator(INDEX).effectiveBalance *Int BASE_REWARD_FACTOR
-          /Int integer_squareroot(get_total_active_balance())
-          /Int BASE_REWARDS_PER_EPOCH
-
+       => ei(500, 3 *Int 10 ^Int 6,
+       ui(MIN_DEPOSIT_AMOUNT, MAX_EFFECTIVE_BALANCE, getValidator(INDEX).effectiveBalance) *UInt64  ci(BASE_REWARD_FACTOR)
+          /UInt64 ui(integer_squareroot(MAX_EFFECTIVE_BALANCE),
+                     integer_squareroot(TOTAL_ETHER_SUPPLY),
+                     integer_squareroot(get_total_active_balance()))
+          /UInt64 ci(BASE_REWARDS_PER_EPOCH)
+       )
 /*
 def get_attestation_deltas(state: BeaconState) -> Tuple[Sequence[Gwei], Sequence[Gwei]]:
     previous_epoch = get_previous_epoch(state)

--- a/beacon-chain.k
+++ b/beacon-chain.k
@@ -1292,11 +1292,11 @@ def get_base_reward(state: BeaconState, index: ValidatorIndex) -> Gwei:
 */
   syntax UInt64 ::= "get_base_reward" "(" Int ")" [function]
   rule get_base_reward(INDEX)
-       => ui(0, MAX_EFFECTIVE_BALANCE, getValidator(INDEX).effectiveBalance) *UInt64  ci(BASE_REWARD_FACTOR)
+       => ensureBounds(0, 3 *Int 10 ^Int 7, ui(0, MAX_EFFECTIVE_BALANCE, getValidator(INDEX).effectiveBalance) *UInt64  ci(BASE_REWARD_FACTOR)
           /UInt64 ui(integer_squareroot(EFFECTIVE_BALANCE_INCREMENT),
                      integer_squareroot(TOTAL_ETHER_SUPPLY),
                      integer_squareroot(get_total_active_balance()))
-          /UInt64 ci(BASE_REWARDS_PER_EPOCH)
+          /UInt64 ci(BASE_REWARDS_PER_EPOCH))
 
 /*
 def get_attestation_deltas(state: BeaconState) -> Tuple[Sequence[Gwei], Sequence[Gwei]]:
@@ -1406,16 +1406,22 @@ def get_attestation_deltas(state: BeaconState) -> Tuple[Sequence[Gwei], Sequence
                        UnslashedIndices,
                        AttestingBalance,
                        #mapMapPair(Rewards => #if contains(I, UnslashedIndices)
-                                              #then Rewards[I <- ei(0, 2 ^Int 64 -Int 1, ci({Rewards[I]}:>Int) +UInt64 get_base_reward(I)
-                                                                  *UInt64 ( ui(0, TOTAL_ETHER_SUPPLY, AttestingBalance)
-                                                                  /UInt64 ci(EFFECTIVE_BALANCE_INCREMENT))
-                                                                  /UInt64 ( ui(EFFECTIVE_BALANCE_INCREMENT, TOTAL_ETHER_SUPPLY, TotalBalance)
-                                                                  /UInt64 ci(EFFECTIVE_BALANCE_INCREMENT)))
-                                                                  ]
+                                              #then Rewards[I <- ei(0, 2 ^Int 64 -Int 1, ui(0,
+                                                 //max bound of Rewards[i]
+                                                 MAX_ATTESTATIONS *Int MAX_SLOTS_PER_EPOCH *Int 3 *Int (3 *Int 10 ^Int 7),
+                                                 {Rewards[I]}:>Int) +UInt64 get_base_reward(I)
+                                                                     *UInt64 ( ui(0, TOTAL_ETHER_SUPPLY, AttestingBalance)
+                                                                     /UInt64 ci(EFFECTIVE_BALANCE_INCREMENT))
+                                                                     /UInt64 ( ui(EFFECTIVE_BALANCE_INCREMENT, TOTAL_ETHER_SUPPLY, TotalBalance)
+                                                                     /UInt64 ci(EFFECTIVE_BALANCE_INCREMENT)))
+                                                                     ]
                                               #else Rewards
                                               #fi,
                                   Penalties => #if notBool contains(I, UnslashedIndices)
-                                               #then Penalties[I <- ei(0, 2 ^Int 64 -Int 1, (ci({Penalties[I]}:>Int) +UInt64 get_base_reward(I)))]
+                                               #then Penalties[I <- ei(0, 2 ^Int 64 -Int 1, ui(0,
+                                                  //max bound of Rewards[i]
+                                                  MAX_ATTESTATIONS *Int MAX_SLOTS_PER_EPOCH *Int 3 *Int (3 *Int 10 ^Int 7),
+                                                  {Penalties[I]}:>Int) +UInt64 get_base_reward(I))]
                                                #else Penalties
                                                #fi) )
 
@@ -1523,7 +1529,8 @@ def get_attestation_deltas(state: BeaconState) -> Tuple[Sequence[Gwei], Sequence
   // penalties[index] += Gwei(BASE_REWARDS_PER_EPOCH * get_base_reward(state, index))
   syntax Map ::= updateBasePenalties(Map, Int) [function]
   rule updateBasePenalties(Penalties, INDEX)
-       => Penalties[INDEX <- ei(0, 2 ^Int 64 -Int 1, ci({Penalties[INDEX]}:>Int) +UInt64 (ci(BASE_REWARDS_PER_EPOCH) *UInt64 get_base_reward(INDEX)))]
+       => Penalties[INDEX <- ei(0, 2 ^Int 64 -Int 1, ui(0, MAX_ATTESTATIONS *Int MAX_SLOTS_PER_EPOCH *Int 3 *Int (3 *Int 10 ^Int 7),
+          {Penalties[INDEX]}:>Int) +UInt64 (ci(BASE_REWARDS_PER_EPOCH) *UInt64 get_base_reward(INDEX)))]
 
   syntax Int ::= numOfValidators() [function]
   rule [[ numOfValidators() => size(ValMap) ]]

--- a/beacon-chain.k
+++ b/beacon-chain.k
@@ -1292,8 +1292,8 @@ def get_base_reward(state: BeaconState, index: ValidatorIndex) -> Gwei:
 */
   syntax UInt64 ::= "get_base_reward" "(" Int ")" [function]
   rule get_base_reward(INDEX)
-       => ui(MIN_DEPOSIT_AMOUNT, MAX_EFFECTIVE_BALANCE, getValidator(INDEX).effectiveBalance) *UInt64  ci(BASE_REWARD_FACTOR)
-          /UInt64 ui(integer_squareroot(MAX_EFFECTIVE_BALANCE),
+       => ui(0, MAX_EFFECTIVE_BALANCE, getValidator(INDEX).effectiveBalance) *UInt64  ci(BASE_REWARD_FACTOR)
+          /UInt64 ui(integer_squareroot(EFFECTIVE_BALANCE_INCREMENT),
                      integer_squareroot(TOTAL_ETHER_SUPPLY),
                      integer_squareroot(get_total_active_balance()))
           /UInt64 ci(BASE_REWARDS_PER_EPOCH)
@@ -1364,7 +1364,9 @@ def get_attestation_deltas(state: BeaconState) -> Tuple[Sequence[Gwei], Sequence
         attesting_balance = get_total_balance(state, unslashed_attesting_indices)
         for index in eligible_validator_indices:
             if index in unslashed_attesting_indices:
-                rewards[index] += get_base_reward(state, index) * attesting_balance // total_balance
+                increment = EFFECTIVE_BALANCE_INCREMENT  # Factored out from balance totals to avoid uint64 overflow
+                reward_numerator = get_base_reward(state, index) * (attesting_balance // increment)
+                rewards[index] = reward_numerator // (total_balance // increment)
             else:
                 penalties[index] += get_base_reward(state, index)
 */
@@ -1405,15 +1407,15 @@ def get_attestation_deltas(state: BeaconState) -> Tuple[Sequence[Gwei], Sequence
                        AttestingBalance,
                        #mapMapPair(Rewards => #if contains(I, UnslashedIndices)
                                               #then Rewards[I <- ei(0, 2 ^Int 64 -Int 1, ci({Rewards[I]}:>Int) +UInt64 get_base_reward(I)
-                                                                  *UInt64 ( ui(MAX_EFFECTIVE_BALANCE, MAX_ATTESTING_BALANCE, AttestingBalance)
+                                                                  *UInt64 ( ui(0, TOTAL_ETHER_SUPPLY, AttestingBalance)
                                                                   /UInt64 ci(EFFECTIVE_BALANCE_INCREMENT))
-                                                                  /UInt64 ( ui(MAX_EFFECTIVE_BALANCE, TOTAL_ETHER_SUPPLY, TotalBalance)
+                                                                  /UInt64 ( ui(EFFECTIVE_BALANCE_INCREMENT, TOTAL_ETHER_SUPPLY, TotalBalance)
                                                                   /UInt64 ci(EFFECTIVE_BALANCE_INCREMENT)))
                                                                   ]
                                               #else Rewards
                                               #fi,
                                   Penalties => #if notBool contains(I, UnslashedIndices)
-                                               #then Penalties[I <- ({Penalties[I]}:>Int +Int ei(0, 2 ^Int 64 -Int 1, get_base_reward(I)))]
+                                               #then Penalties[I <- ei(0, 2 ^Int 64 -Int 1, (ci({Penalties[I]}:>Int) +UInt64 get_base_reward(I)))]
                                                #else Penalties
                                                #fi) )
 
@@ -1521,7 +1523,7 @@ def get_attestation_deltas(state: BeaconState) -> Tuple[Sequence[Gwei], Sequence
   // penalties[index] += Gwei(BASE_REWARDS_PER_EPOCH * get_base_reward(state, index))
   syntax Map ::= updateBasePenalties(Map, Int) [function]
   rule updateBasePenalties(Penalties, INDEX)
-       => Penalties[INDEX <- {Penalties[INDEX]}:>Int +Int (BASE_REWARDS_PER_EPOCH *Int ei(0, 2 ^Int 64 -Int 1, get_base_reward(INDEX)))]
+       => Penalties[INDEX <- ei(0, 2 ^Int 64 -Int 1, ci({Penalties[INDEX]}:>Int) +UInt64 (ci(BASE_REWARDS_PER_EPOCH) *UInt64 get_base_reward(INDEX)))]
 
   syntax Int ::= numOfValidators() [function]
   rule [[ numOfValidators() => size(ValMap) ]]
@@ -1702,8 +1704,8 @@ def process_slashings(state: BeaconState) -> None:
        ... </k>
 
   syntax KItem ::= "processSlashingsLoop" "(" i: Int "," nrValidators: Int "," Int "," Int ")"
-  rule (. => decrease_balance(I, (getValidator(I).effectiveBalance /Int EFFECTIVE_BALANCE_INCREMENT *Int minInt(sumSlashings() *Int 3,
-                                  TotalBalance)) /Int TotalBalance *Int EFFECTIVE_BALANCE_INCREMENT))
+  rule (. => decrease_balance(I, ei(0, 2 ^Int 64 -Int 1, (ui(0, MAX_EFFECTIVE_BALANCE, getValidator(I).effectiveBalance) /UInt64 ci(EFFECTIVE_BALANCE_INCREMENT) *UInt64 ui(0, TotalBalance, minInt(sumSlashings() *Int 3,
+                                  TotalBalance)) /UInt64 ui(EFFECTIVE_BALANCE_INCREMENT, TOTAL_ETHER_SUPPLY, TotalBalance) *UInt64 ci(EFFECTIVE_BALANCE_INCREMENT)))))
        ~> processSlashingsLoop(I => I +Int 1, N, EP, TotalBalance)
     requires I <Int N
      andBool getValidator(I).slashed andBool EP +Int EPOCHS_PER_SLASHINGS_VECTOR /Int 2 ==K getValidator(I).withdrawableEpoch

--- a/beacon-chain.k
+++ b/beacon-chain.k
@@ -1290,15 +1290,14 @@ def get_base_reward(state: BeaconState, index: ValidatorIndex) -> Gwei:
     effective_balance = state.validators[index].effective_balance
     return Gwei(effective_balance * BASE_REWARD_FACTOR // integer_squareroot(total_balance) // BASE_REWARDS_PER_EPOCH)
 */
-  syntax Int ::= "get_base_reward" "(" Int ")" [function]
+  syntax UInt64 ::= "get_base_reward" "(" Int ")" [function]
   rule get_base_reward(INDEX)
-       => ei(500, 3 *Int 10 ^Int 6,
-       ui(MIN_DEPOSIT_AMOUNT, MAX_EFFECTIVE_BALANCE, getValidator(INDEX).effectiveBalance) *UInt64  ci(BASE_REWARD_FACTOR)
+       => ui(MIN_DEPOSIT_AMOUNT, MAX_EFFECTIVE_BALANCE, getValidator(INDEX).effectiveBalance) *UInt64  ci(BASE_REWARD_FACTOR)
           /UInt64 ui(integer_squareroot(MAX_EFFECTIVE_BALANCE),
                      integer_squareroot(TOTAL_ETHER_SUPPLY),
                      integer_squareroot(get_total_active_balance()))
           /UInt64 ci(BASE_REWARDS_PER_EPOCH)
-       )
+
 /*
 def get_attestation_deltas(state: BeaconState) -> Tuple[Sequence[Gwei], Sequence[Gwei]]:
     previous_epoch = get_previous_epoch(state)
@@ -1403,12 +1402,13 @@ def get_attestation_deltas(state: BeaconState) -> Tuple[Sequence[Gwei], Sequence
                        UnslashedIndices,
                        AttestingBalance,
                        #mapMapPair(Rewards => #if contains(I, UnslashedIndices)
-                                              #then Rewards[I <- ({Rewards[I]}:>Int +Int get_base_reward(I)
-                                                                  *Int AttestingBalance /Int TotalBalance)]
+                                              #then Rewards[I <- ei(0, 2 ^Int 64 -Int 1, ci({Rewards[I]}:>Int) +UInt64 get_base_reward(I)
+                                                                  *UInt64 ui(MAX_EFFECTIVE_BALANCE, MAX_ATTESTING_BALANCE, AttestingBalance)
+                                                                  /UInt64 ui(MAX_EFFECTIVE_BALANCE, TOTAL_ETHER_SUPPLY, TotalBalance))]
                                               #else Rewards
                                               #fi,
                                   Penalties => #if notBool contains(I, UnslashedIndices)
-                                               #then Penalties[I <- ({Penalties[I]}:>Int +Int get_base_reward(I))]
+                                               #then Penalties[I <- ({Penalties[I]}:>Int +Int ei(0, 2 ^Int 64 -Int 1, get_base_reward(I)))]
                                                #else Penalties
                                                #fi) )
 
@@ -1448,11 +1448,11 @@ def get_attestation_deltas(state: BeaconState) -> Tuple[Sequence[Gwei], Sequence
 
   // max_attester_reward = get_base_reward(state, index) - proposer_reward
   syntax Int ::= computeMaxAttReward(Int /*Proposer index*/ , Int /*proposer reward*/) [function]
-  rule computeMaxAttReward(INDEX, REWARD) => get_base_reward(INDEX) -Int REWARD
+  rule computeMaxAttReward(INDEX, REWARD) => ei(0, 2 ^Int 64 -Int 1, get_base_reward(INDEX)) -Int REWARD
 
   // proposer_reward = Gwei(get_base_reward(state, index) // PROPOSER_REWARD_QUOTIENT)
   syntax Int ::= computeProposerReward(Int /*proposer index*/) [function]
-  rule computeProposerReward(INDEX) => get_base_reward(INDEX) /Int PROPOSER_REWARD_QUOTIENT
+  rule computeProposerReward(INDEX) => ei(0, 2 ^Int 64 -Int 1, get_base_reward(INDEX)) /Int PROPOSER_REWARD_QUOTIENT
 
   /*
   attestation = min([
@@ -1516,7 +1516,7 @@ def get_attestation_deltas(state: BeaconState) -> Tuple[Sequence[Gwei], Sequence
   // penalties[index] += Gwei(BASE_REWARDS_PER_EPOCH * get_base_reward(state, index))
   syntax Map ::= updateBasePenalties(Map, Int) [function]
   rule updateBasePenalties(Penalties, INDEX)
-       => Penalties[INDEX <- {Penalties[INDEX]}:>Int +Int (BASE_REWARDS_PER_EPOCH *Int get_base_reward(INDEX))]
+       => Penalties[INDEX <- {Penalties[INDEX]}:>Int +Int (BASE_REWARDS_PER_EPOCH *Int ei(0, 2 ^Int 64 -Int 1, get_base_reward(INDEX)))]
 
   syntax Int ::= numOfValidators() [function]
   rule [[ numOfValidators() => size(ValMap) ]]

--- a/constants-bounds-check.k
+++ b/constants-bounds-check.k
@@ -1,0 +1,177 @@
+module CONSTANTS
+  imports DOMAINS
+
+  // (Non-configurable) constants
+  //====================================================
+  syntax Version ::= "GENESIS_FORK_VERSION"
+  rule GENESIS_FORK_VERSION => "\x00\x00\x00\x01"             [macro]
+  syntax Int ::= "FAR_FUTURE_EPOCH"
+  rule FAR_FUTURE_EPOCH => 2 ^Int 64 -Int 1                   [macro]
+  syntax Int ::= "BASE_REWARDS_PER_EPOCH"
+  rule BASE_REWARDS_PER_EPOCH => 4                            [macro]
+  syntax Int ::= "DEPOSIT_CONTRACT_TREE_DEPTH"
+  rule DEPOSIT_CONTRACT_TREE_DEPTH => 2 ^Int 5                [macro]
+  syntax Int ::= "JUSTIFICATION_BITS_LENGTH"
+  rule JUSTIFICATION_BITS_LENGTH => 4                         [macro]
+  syntax String ::= "ENDIANNESS"
+  rule ENDIANNESS => "little"                                 [macro]
+
+  // Configuration -- Misc
+  //====================================================
+  syntax Int ::= "MAX_COMMITTEES_PER_SLOT"
+  rule MAX_COMMITTEES_PER_SLOT => 4                           [macro]
+  syntax Int ::= "TARGET_COMMITTEE_SIZE"
+  rule TARGET_COMMITTEE_SIZE => 4                             [macro]
+  syntax Int ::= "MAX_VALIDATORS_PER_COMMITTEE"
+  rule MAX_VALIDATORS_PER_COMMITTEE => 2048                   [macro]
+  syntax Int ::= "MIN_PER_EPOCH_CHURN_LIMIT"
+  rule MIN_PER_EPOCH_CHURN_LIMIT => 4                         [macro]
+  syntax Int ::= "CHURN_LIMIT_QUOTIENT"
+  rule CHURN_LIMIT_QUOTIENT => 65536                          [macro]
+  syntax Int ::= "SHUFFLE_ROUND_COUNT"
+  rule SHUFFLE_ROUND_COUNT => 10                              [macro]
+  syntax Int ::= "MIN_GENESIS_ACTIVE_VALIDATOR_COUNT"
+  rule MIN_GENESIS_ACTIVE_VALIDATOR_COUNT => 64               [macro]
+  syntax Int ::= "MIN_GENESIS_TIME"
+  rule MIN_GENESIS_TIME => 1578009600                         [macro]
+
+  // Configuration -- fork choice
+  //====================================================
+  syntax Int ::= "SAFE_SLOTS_TO_UPDATE_JUSTIFIED"
+  rule SAFE_SLOTS_TO_UPDATE_JUSTIFIED => 2                    [macro] 
+
+  // Configuration -- Gwei values
+  //====================================================
+  syntax Int ::= "MIN_DEPOSIT_AMOUNT"
+  rule MIN_DEPOSIT_AMOUNT => 2 ^Int 0 *Int 10 ^Int 9          [macro]
+
+  syntax Int ::= "MAX_EFFECTIVE_BALANCE"
+  rule MAX_EFFECTIVE_BALANCE => 2 ^Int 5 *Int 10 ^Int 9       [macro]
+
+  // syntax Int ::= "MIN_DEPOSIT_AMOUNT"
+  // rule MIN_DEPOSIT_AMOUNT => 1000000000                       [macro]
+  // syntax Int ::= "MAX_EFFECTIVE_BALANCE"
+  // rule MAX_EFFECTIVE_BALANCE => 32000000000                   [macro]
+  syntax Int ::= "EJECTION_BALANCE"
+  rule EJECTION_BALANCE => 2 ^Int 4 *Int 10 ^Int 9            [macro]
+  // syntax Int ::= "EJECTION_BALANCE"
+  // rule EJECTION_BALANCE => 16000000000                        [macro]
+  syntax Int ::= "EFFECTIVE_BALANCE_INCREMENT"
+  rule EFFECTIVE_BALANCE_INCREMENT => 2 ^Int 0 *Int 10 ^Int 9 [macro]
+  // syntax Int ::= "EFFECTIVE_BALANCE_INCREMENT"
+  // rule EFFECTIVE_BALANCE_INCREMENT => 1000000000              [macro]
+
+  // Configuration -- Initial values
+  //====================================================
+  syntax Int ::= "GENESIS_SLOT"
+  rule GENESIS_SLOT => 0                                      [macro]
+  syntax Int ::= "GENESIS_EPOCH"
+  rule GENESIS_EPOCH => 0                                     [macro]
+  syntax Bytes ::= "BLS_WITHDRAWAL_PREFIX"
+  rule BLS_WITHDRAWAL_PREFIX => "\x00"                        [macro]
+
+  // Configuration -- Time parameters
+  //====================================================
+  syntax Int ::= "MIN_GENESIS_DELAY"
+  rule MIN_GENESIS_DELAY => 300                               [macro]
+  syntax Int ::= "SECONDS_PER_SLOT"
+  rule SECONDS_PER_SLOT => 6                                  [macro]
+  syntax Int ::= "MIN_ATTESTATION_INCLUSION_DELAY"
+  rule MIN_ATTESTATION_INCLUSION_DELAY => 1                   [macro]
+  syntax Int ::= "SLOTS_PER_EPOCH"
+  rule SLOTS_PER_EPOCH => 8                                   [macro]
+  syntax Int ::= "MIN_SEED_LOOKAHEAD"
+  rule MIN_SEED_LOOKAHEAD => 1                                [macro]
+  syntax Int ::= "MAX_SEED_LOOKAHEAD"
+  rule MAX_SEED_LOOKAHEAD => 4                                [macro]
+  syntax Int ::= "SLOTS_PER_ETH1_VOTING_PERIOD"
+  rule SLOTS_PER_ETH1_VOTING_PERIOD => 16                     [macro]
+  syntax Int ::= "SLOTS_PER_HISTORICAL_ROOT"
+  rule SLOTS_PER_HISTORICAL_ROOT => 64                        [macro]
+  syntax Int ::= "MIN_VALIDATOR_WITHDRAWABILITY_DELAY"
+  rule MIN_VALIDATOR_WITHDRAWABILITY_DELAY => 256             [macro]
+  syntax Int ::= "PERSISTENT_COMMITTEE_PERIOD"
+  rule PERSISTENT_COMMITTEE_PERIOD => 2048                    [macro]
+  syntax Int ::= "MAX_EPOCHS_PER_CROSSLINK"
+  rule MAX_EPOCHS_PER_CROSSLINK => 4                          [macro]
+  syntax Int ::= "MIN_EPOCHS_TO_INACTIVITY_PENALTY"
+  rule MIN_EPOCHS_TO_INACTIVITY_PENALTY => 4                  [macro]
+  syntax Int ::= "EARLY_DERIVED_SECRET_PENALTY_MAX_FUTURE_EPOCHS"
+  rule EARLY_DERIVED_SECRET_PENALTY_MAX_FUTURE_EPOCHS => 4096 [macro]
+  syntax Int ::= "EPOCHS_PER_CUSTODY_PERIOD"
+  rule EPOCHS_PER_CUSTODY_PERIOD => 4                         [macro]
+  syntax Int ::= "CUSTODY_PERIOD_TO_RANDAO_PADDING"
+  rule CUSTODY_PERIOD_TO_RANDAO_PADDING => 4                  [macro]
+
+  // Configuration -- State list lengths
+  //====================================================
+  syntax Int ::= "EPOCHS_PER_HISTORICAL_VECTOR"
+  rule EPOCHS_PER_HISTORICAL_VECTOR => 64                     [macro]
+  syntax Int ::= "EPOCHS_PER_SLASHINGS_VECTOR"
+  rule EPOCHS_PER_SLASHINGS_VECTOR => 64                      [macro]
+  syntax Int ::= "HISTORICAL_ROOTS_LIMIT"
+  rule HISTORICAL_ROOTS_LIMIT => 16777216                     [macro]
+  syntax Int ::= "VALIDATOR_REGISTRY_LIMIT"
+  rule VALIDATOR_REGISTRY_LIMIT => 1099511627776              [macro]
+
+  // Configuration -- Rewards and penalties
+  //====================================================
+  syntax Int ::= "BASE_REWARD_FACTOR"
+  rule BASE_REWARD_FACTOR => 2 ^Int 6                         [macro]
+  // syntax Int ::= "BASE_REWARD_FACTOR"
+  // rule BASE_REWARD_FACTOR => 64                               [macro]
+  syntax Int ::= "WHISTLEBLOWER_REWARD_QUOTIENT"
+  rule WHISTLEBLOWER_REWARD_QUOTIENT => 512                   [macro]
+  syntax Int ::= "PROPOSER_REWARD_QUOTIENT"
+  rule PROPOSER_REWARD_QUOTIENT => 8                          [macro]
+  syntax Int ::= "INACTIVITY_PENALTY_QUOTIENT"
+  rule INACTIVITY_PENALTY_QUOTIENT => 33554432                [macro]
+  syntax Int ::= "MIN_SLASHING_PENALTY_QUOTIENT"
+  rule MIN_SLASHING_PENALTY_QUOTIENT => 32                    [macro]
+
+  // Configuration -- Max operations per block
+  //====================================================
+  syntax Int ::= "MAX_PROPOSER_SLASHINGS"
+  rule MAX_PROPOSER_SLASHINGS => 16                           [macro]
+  syntax Int ::= "MAX_ATTESTER_SLASHINGS"
+  rule MAX_ATTESTER_SLASHINGS => 1                            [macro]
+  syntax Int ::= "MAX_ATTESTATIONS"
+  rule MAX_ATTESTATIONS => 128                                [macro]
+  syntax Int ::= "MAX_DEPOSITS"
+  rule MAX_DEPOSITS => 16                                     [macro]
+  syntax Int ::= "MAX_VOLUNTARY_EXITS"
+  rule MAX_VOLUNTARY_EXITS => 16                              [macro]
+  // syntax Int ::= "MAX_TRANSFERS"
+  // rule MAX_TRANSFERS => 0                                     [macro]
+
+  // Configuration -- domain types
+  //====================================================
+  syntax DomainType ::= "DOMAIN_BEACON_PROPOSER"
+  rule DOMAIN_BEACON_PROPOSER => "\x00\x00\x00\x00"           [macro]
+  syntax DomainType ::= "DOMAIN_BEACON_ATTESTER"
+  rule DOMAIN_BEACON_ATTESTER => "\x01\x00\x00\x00"           [macro]
+  syntax DomainType ::= "DOMAIN_RANDAO"
+  rule DOMAIN_RANDAO => "\x02\x00\x00\x00"                    [macro]
+  syntax DomainType ::= "DOMAIN_DEPOSIT"
+  rule DOMAIN_DEPOSIT => "\x03\x00\x00\x00"                   [macro]
+  syntax DomainType ::= "DOMAIN_VOLUNTARY_EXIT"
+  rule DOMAIN_VOLUNTARY_EXIT => "\x04\x00\x00\x00"            [macro]
+
+  // Configuration --  Validator
+  //====================================================
+  syntax Int ::= "ETH1_FOLLOW_DISTANCE"
+  rule ETH1_FOLLOW_DISTANCE => 16                             [macro]
+  syntax Int ::= "TARGET_AGGREGATORS_PER_COMMITTEE"
+  rule TARGET_AGGREGATORS_PER_COMMITTEE => 16                 [macro]
+  syntax Int ::= "RANDOM_SUBNETS_PER_VALIDATOR"
+  rule RANDOM_SUBNETS_PER_VALIDATOR => 16                     [macro]
+  syntax Int ::= "EPOCHS_PER_RANDOM_SUBNET_SUBSCRIPTION"
+  rule EPOCHS_PER_RANDOM_SUBNET_SUBSCRIPTION => 256           [macro]
+  syntax Int ::= "SECONDS_PER_ETH1_BLOCK"
+  rule SECONDS_PER_ETH1_BLOCK => 14                           [macro]
+
+  // added for bounds checking
+  syntax Int ::= "TOTAL_ETHER_SUPPLY"
+  rule TOTAL_ETHER_SUPPLY => 10 ^Int 10 *Int 10 ^Int 9         [macro]
+
+endmodule

--- a/constants-bounds-check.k
+++ b/constants-bounds-check.k
@@ -80,6 +80,8 @@ module CONSTANTS
   rule MIN_ATTESTATION_INCLUSION_DELAY => 1                   [macro]
   syntax Int ::= "SLOTS_PER_EPOCH"
   rule SLOTS_PER_EPOCH => 8                                   [macro]
+  syntax Int ::= "MAX_SLOTS_PER_EPOCH"
+  rule MAX_SLOTS_PER_EPOCH => 32                              [macro]
   syntax Int ::= "MIN_SEED_LOOKAHEAD"
   rule MIN_SEED_LOOKAHEAD => 1                                [macro]
   syntax Int ::= "MAX_SEED_LOOKAHEAD"

--- a/constants-minimal.k
+++ b/constants-minimal.k
@@ -70,6 +70,8 @@ module CONSTANTS
   rule MIN_ATTESTATION_INCLUSION_DELAY => 1                   [macro]
   syntax Int ::= "SLOTS_PER_EPOCH"
   rule SLOTS_PER_EPOCH => 8                                   [macro]
+  syntax Int ::= "MAX_SLOTS_PER_EPOCH"
+  rule MAX_SLOTS_PER_EPOCH => 8                               [macro]
   syntax Int ::= "MIN_SEED_LOOKAHEAD"
   rule MIN_SEED_LOOKAHEAD => 1                                [macro]
   syntax Int ::= "MAX_SEED_LOOKAHEAD"

--- a/constants-minimal.k
+++ b/constants-minimal.k
@@ -11,8 +11,6 @@ module CONSTANTS
   rule BASE_REWARDS_PER_EPOCH => 4                            [macro]
   syntax Int ::= "DEPOSIT_CONTRACT_TREE_DEPTH"
   rule DEPOSIT_CONTRACT_TREE_DEPTH => 2 ^Int 5                [macro]
-  syntax Int ::= "SECONDS_PER_DAY"
-  rule SECONDS_PER_DAY => 86400                               [macro]
   syntax Int ::= "JUSTIFICATION_BITS_LENGTH"
   rule JUSTIFICATION_BITS_LENGTH => 4                         [macro]
   syntax String ::= "ENDIANNESS"

--- a/constants-minimal.k
+++ b/constants-minimal.k
@@ -158,5 +158,10 @@ module CONSTANTS
   syntax Int ::= "SECONDS_PER_ETH1_BLOCK"
   rule SECONDS_PER_ETH1_BLOCK => 14                           [macro]
 
-  //TODO: Some phase 1 stuff here
+  // for bounds checking
+  syntax Int ::= "TOTAL_ETHER_SUPPLY"
+  rule TOTAL_ETHER_SUPPLY => 10 ^Int 6 *Int 10 ^Int 9         [macro]
+
+
+//TODO: Some phase 1 stuff here
 endmodule

--- a/hash-tree.k
+++ b/hash-tree.k
@@ -245,20 +245,6 @@ def chunkify(bytez):
   rule merkleMergeLoop(H => hashConcat({TMP[J]}:>Bytes, H), I, COUNT, DEPTH, TMP, J => J +Int 1)
     requires notBool (I &Int (1 <<Int J) ==Int 0)
 
-/* def is_bottom_layer_kind(typ: SSZType):
-    return (
-        isinstance(typ, BasicType) or
-        (issubclass(typ, Elements) and isinstance(typ.elem_type, BasicType))
-    )
-*/
-  syntax Bool ::= "is_bottom_layer_kind" "(" ValueOrList ")"          [function]
-  rule is_bottom_layer_kind(_:BasicValue) => true
-  rule is_bottom_layer_kind(_:Bytes) => true
-  rule is_bottom_layer_kind(_:IntList) => true
-  rule is_bottom_layer_kind(_:BitList) => true
-
-  rule is_bottom_layer_kind(_) => false                               [owise]
-
 /* def hash_tree_root(obj: SSZValue):
     if isinstance(obj, Series):
         if is_bottom_layer_kind(obj.type()):

--- a/types.k
+++ b/types.k
@@ -555,13 +555,6 @@ def bytes_to_int(data: bytes) -> uint64:
     requires A =/=Int 0
   rule bit_length(0) => 0
 
-  syntax Int ::= sum( IntList ) [function]
-  rule sum( IL ) => sumAux(IL, 0)
-
-  syntax Int ::= sumAux( IntList, Int ) [function]
-  rule sumAux(I:Int IL => IL, S => S +Int I)
-  rule sumAux(.IntList, S) => S
-
   syntax Int ::= maxAux ( IntList )       [function, klabel(maxAux)]
                | maxAux ( IntList , Int ) [function, klabel(maxAux2)]
   rule maxAux( I:Int IL ) => maxAux(IL, I)
@@ -585,11 +578,6 @@ def bytes_to_int(data: bytes) -> uint64:
   rule strictlyMinIndex(I IL, M) => I requires I <Int M
   rule strictlyMinIndex(I IL, M) => M requires M <Int I
   rule strictlyMinIndex(.IntList, M) => M
-
-  // Note: If listExcept(IL, I) removes every occurrence of I in IL, then difference here will do the same
-  syntax IntList ::= listDiff(IntList, IntList)                       [function]
-  rule listDiff(IL => listExcept(IL, I), I IL2 => IL2)
-  rule listDiff(IL, .IntList) => IL
 
   syntax Bool ::= contains( Int, IntList )                            [function]
   rule contains(A, A IL ) => true

--- a/uint64.k
+++ b/uint64.k
@@ -9,6 +9,9 @@ syntax UInt64 ::= #uint64(Int, Int, Int) // {min, max} bounds, value (64-bit)
 syntax UInt64 ::= ui(Int, Int, Int) [function]
 rule ui(L, U, V) => #uint64(L, U, V) requires 0 <=Int L andBool L <=Int V andBool V <=Int U andBool U <Int 2 ^Int 64
 
+syntax UInt64 ::= ensureBounds(Int, Int, UInt64) [function]
+rule ensureBounds(L, U, #uint64(L0, U0, V)) => #uint64(L0, U0, V) requires L <=Int L0 andBool U0 <=Int U
+
 // arithmetic
 syntax UInt64 ::= left: // no functional, no hook
                 UInt64 "*UInt64" UInt64 [function, left, klabel(_*UInt64_), smtlib(mulUInt64)]

--- a/uint64.k
+++ b/uint64.k
@@ -1,0 +1,33 @@
+module UINT64
+
+imports INT
+
+// bounded values
+syntax UInt64 ::= #uint64(Int, Int, Int) // {min, max} bounds, value (64-bit)
+
+// constructor
+syntax UInt64 ::= ui(Int, Int, Int) [function]
+rule ui(L, U, V) => #uint64(L, U, V) requires 0 <=Int L andBool L <=Int V andBool V <=Int U andBool U <Int 2 ^Int 64
+
+// arithmetic
+syntax UInt64 ::= left: // no functional, no hook
+                UInt64 "*UInt64" UInt64 [function, left, klabel(_*UInt64_), smtlib(mulUInt64)]
+              | UInt64 "/UInt64" UInt64 [function, left, klabel(_/UInt64_), smtlib(divUInt64)]
+              > left:
+                UInt64 "+UInt64" UInt64 [function, left, klabel(_+UInt64_), smtlib(addUInt64)]
+              | UInt64 "-UInt64" UInt64 [function, left, klabel(_-UInt64_), smtlib(subUInt64)]
+
+rule #uint64(L1, U1, V1) *UInt64 #uint64(L2, U2, V2) => ui(          L1 *Int L2,            U1 *Int U2,  V1 *Int V2)
+rule #uint64(L1, U1, V1) /UInt64 #uint64(L2, U2, V2) => ui(          L1 /Int U2,            U1 /Int L2,  V1 /Int V2)
+rule #uint64(L1, U1, V1) +UInt64 #uint64(L2, U2, V2) => ui(          L1 +Int L2,            U1 +Int U2,  V1 +Int V2)
+rule #uint64(L1, U1, V1) -UInt64 #uint64(L2, U2, V2) => ui(maxInt(0, L1 -Int U2), maxInt(0, U1 -Int L2), V1 -Int V2) // requires V1 >=Int V2
+
+// lift constants
+syntax UInt64 ::= ci(Int) [function]
+rule ci(V) => ui(V, V, V) requires V >=Int 0
+
+// ensure bounds
+syntax Int ::= ei(Int, Int, UInt64) [function]
+rule ei(L, U, #uint64(L0, U0, V)) => V requires L <=Int L0 andBool U0 <=Int U
+
+endmodule


### PR DESCRIPTION
Adds bounds checking to some key calculations in `get_attestation_deltas`, in the spirit of @daejunpark s [bounds-check branch](https://github.com/runtimeverification/beacon-chain-spec/tree/bounds-check). This also adds the bounds checking as a target for ci so that it is run on every PR